### PR TITLE
Add context wrap to urlopen response

### DIFF
--- a/advertools/sitemaps.py
+++ b/advertools/sitemaps.py
@@ -490,7 +490,8 @@ def sitemap_to_df(sitemap_url, max_workers=8, recursive=True):
     else:
         xml_text = urlopen(Request(sitemap_url, headers=headers))
         resp_headers = xml_text.getheaders()
-    xml_string = xml_text.read()
+    with xml_text:
+        xml_string = xml_text.read()
     root = ElementTree.fromstring(xml_string)
 
     sitemap_df = pd.DataFrame()


### PR DESCRIPTION
xml_text.read() is called without closing connection, this may result xml_string not complete. ElementTree.fromstring may raise error because of incomplete string.

The error situation can be reproduced on ubuntu 18.04, with prtimes sitemap at url: https://prtimes.jp/sitemap-news.xml

This "with" wrap automatically closes the connection when the read is done, also prevent the above error. Verified OK in our project for both plain HTML and gzipped case.