### PR TITLE
Update _yt_helpers.py

### DIFF
--- a/advertools/_yt_helpers.py
+++ b/advertools/_yt_helpers.py
@@ -38,7 +38,7 @@ def _json_to_df(json_resp, params):
     for col in df:
         if 'Count' in col:
             try:
-                df[col] = df[col].astype(int)
+                df[col] = df[col].astype('int64')
             except ValueError:
                 continue
         if ('published' in col) or ('updated' in col):


### PR DESCRIPTION
dtype int translates to c datatype long, which is a 32-bit Integer on Windows. So, for very large channels, the total number of views exceeds the supported value range (try searching for channels with videos about "Cute cat", which will return channels with > 5bn views), leading to an OverflowError ("Python int too large to convert to C long"). Using dtype 'int64' explicitly uses a 64-bit Integer also on Windows machines and solves the issue.