### PR TITLE
fix: forward request_headers in recursive sitemap_to_df calls

### DIFF
--- a/advertools/sitemaps.py
+++ b/advertools/sitemaps.py
@@ -522,7 +522,7 @@ def sitemap_to_df(sitemap_url, max_workers=8, recursive=True, request_headers=No
     if sitemap_url.endswith("robots.txt"):
         return pd.concat(
             [
-                sitemap_to_df(sitemap, recursive=recursive)
+                sitemap_to_df(sitemap, recursive=recursive, request_headers=request_headers)
                 for sitemap in _sitemaps_from_robotstxt(sitemap_url, final_headers)
             ],
             ignore_index=True,
@@ -584,7 +584,7 @@ def sitemap_to_df(sitemap_url, max_workers=8, recursive=True, request_headers=No
         with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             to_do = []
             for sitemap in sitemap_url_list:
-                future = executor.submit(sitemap_to_df, sitemap)
+                future = executor.submit(sitemap_to_df, sitemap, request_headers=request_headers)
                 to_do.append(future)
             done_iter = futures.as_completed(to_do)
             for future in done_iter:


### PR DESCRIPTION
Fixes #407

`sitemap_to_df` accepts a `request_headers` parameter for setting custom request headers (user-agent, auth tokens, etc.), but when the function recurses into a sitemap index or a robots.txt file, the headers are dropped and subsequent requests use defaults.

This PR forwards `request_headers` in both recursive paths:

1. **robots.txt path** (L524): when resolving sitemap URLs from a robots.txt file, the individual `sitemap_to_df` calls now pass `request_headers`
2. **sitemap index path** (L586): when using `ThreadPoolExecutor` to fetch sub-sitemaps from a sitemap index, `request_headers` is now passed to each worker call

Without this fix, any server requiring a specific `User-Agent` or auth header would reject the recursive requests even when headers are passed to the top-level call.