### PR TITLE
Fix invalid escape sequences in module docstrings (crawlytics, robotstxt)

### DIFF
--- a/advertools/crawlytics.py
+++ b/advertools/crawlytics.py
@@ -1,4 +1,4 @@
-"""
+r"""
 After crawling a website, or a bunch of URLs, you mostly likely want to analyze the data
 and gain a better undersanding of the website's structure, strategy, and content. You
 probably also want to check for technical issues that the site might have.

--- a/advertools/robotstxt.py
+++ b/advertools/robotstxt.py
@@ -1,4 +1,4 @@
-"""
+r"""
 .. _robotstxt:
 
 🤖 Analyze and Test robots.txt Files on a Large Scale


### PR DESCRIPTION
Python 3.12 raises `SyntaxWarning` for invalid escape sequences in regular strings (like `\_`, `\*`). These have been `DeprecationWarning` since 3.6.

`crawlytics.py` and `robotstxt.py` both have module-level docstrings with backslash sequences used for RST markup. The fix is to prefix the opening `"""` with `r` to make them raw strings, which is the standard approach for docstrings containing backslash patterns.
