### PR TITLE
fix: convert docstrings with invalid escape sequences to raw strings

### DIFF
--- a/advertools/ad_from_string.py
+++ b/advertools/ad_from_string.py
@@ -1,4 +1,4 @@
-"""
+r"""
 .. _ad_from_string:
 
 Create Ads Using Long Descriptive Text (top-down approach)

--- a/advertools/crawlytics.py
+++ b/advertools/crawlytics.py
@@ -1,4 +1,4 @@
-"""
+r"""
 After crawling a website, or a bunch of URLs, you mostly likely want to analyze the data
 and gain a better undersanding of the website's structure, strategy, and content. You
 probably also want to check for technical issues that the site might have.
@@ -295,7 +295,7 @@ __all__ = [
 
 
 def redirects(crawldf):
-    """Create a tidy DataFrame for the redirects in `crawldf` with the columns:
+    r"""Create a tidy DataFrame for the redirects in `crawldf` with the columns:
 
     - url: All the URLs in the redirect (chain).
     - status: The status code of each URL.
@@ -374,7 +374,7 @@ def redirects(crawldf):
 
 
 def links(crawldf, internal_url_regex=None):
-    """Summarize links from a crawl DataFrame.
+    r"""Summarize links from a crawl DataFrame.
 
     Parameters
     ----------
@@ -436,7 +436,7 @@ def links(crawldf, internal_url_regex=None):
 
 
 def images(crawldf):
-    """Summarize crawled images from a crawl DataFrame.
+    r"""Summarize crawled images from a crawl DataFrame.
 
     Parameters
     ----------
@@ -493,7 +493,7 @@ def images(crawldf):
 
 
 def jl_subset(filepath, columns=None, regex=None, chunksize=500):
-    """Read a jl file extracting selected `columns` and/or columns matching `regex`.
+    r"""Read a jl file extracting selected `columns` and/or columns matching `regex`.
 
     Parameters
     ----------
@@ -549,7 +549,7 @@ def jl_subset(filepath, columns=None, regex=None, chunksize=500):
 
 
 def jl_to_parquet(jl_filepath, parquet_filepath):
-    """Convert a jsonlines crawl file to the parquet format.
+    r"""Convert a jsonlines crawl file to the parquet format.
 
     Parameters
     ----------
@@ -577,7 +577,7 @@ def jl_to_parquet(jl_filepath, parquet_filepath):
 
 
 def parquet_columns(filepath):
-    """Get column names and datatypes of a parquet file.
+    r"""Get column names and datatypes of a parquet file.
 
     Parameters
     ----------
@@ -597,7 +597,7 @@ def parquet_columns(filepath):
 
 
 def compare(df1, df2, column, keep_equal=False):
-    """Compare common URLs in two crawl DataFrames with respect to `column`.
+    r"""Compare common URLs in two crawl DataFrames with respect to `column`.
 
     There are three main options that you might select for comparison:
 
@@ -669,7 +669,7 @@ def compare(df1, df2, column, keep_equal=False):
 
 
 def running_crawls():
-    """Get details of currently running spiders.
+    r"""Get details of currently running spiders.
 
     Get a DataFrame showing the following details:
 
@@ -744,7 +744,7 @@ def running_crawls():
 
 
 def generate_markdown(crawldf):
-    """
+    r"""
     Generate markdown strings using h1-h6 headings and body_text.
 
     Parameters
@@ -763,10 +763,10 @@ def generate_markdown(crawldf):
     >>> crawldf = pd.read_json("output_file.jsonl", lines=True)
     >>> md = adv.crawlytics.generate_markdown(crawldf)
 
-    """
+    r"""
 
     def convert_single_row(row):
-        """Convert a single row to markdown."""
+        r"""Convert a single row to markdown."""
         body_text = (
             "" if pd.isna(row.get("body_text", "")) else str(row.get("body_text", ""))
         )

--- a/advertools/partition.py
+++ b/advertools/partition.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Text partitioning with Python
 =============================
 
@@ -167,13 +167,13 @@ headings and the content between them.
    ----
    Content for section 2.
 
-"""
+r"""
 
 import re
 
 
 def partition(text, regex, flags=0):
-    """Partition a string based on a regex pattern.
+    r"""Partition a string based on a regex pattern.
 
     Splits the `text` by all occurrences of `regex`. The resulting list
     includes both the substrings between the matches and the matches

--- a/advertools/robotstxt.py
+++ b/advertools/robotstxt.py
@@ -1,4 +1,4 @@
-"""
+r"""
 .. _robotstxt:
 
 🤖 Analyze and Test robots.txt Files on a Large Scale

--- a/advertools/youtube.py
+++ b/advertools/youtube.py
@@ -1,4 +1,4 @@
-"""
+r"""
 .. _youtube:
 
 YouTube Data API
@@ -242,7 +242,7 @@ def videos_list(
 
 
 def video_categories_list(key, part, id=None, regionCode=None, hl=None):
-    """Returns a list of categories that can be associated with YouTube videos.
+    r"""Returns a list of categories that can be associated with YouTube videos.
 
     *Required parameters:*
 
@@ -695,7 +695,7 @@ def subscriptions_list(
 
 
 def i18n_regions_list(key, part, hl=None):
-    """Returns a list of content regions that the YouTube website supports.
+    r"""Returns a list of content regions that the YouTube website supports.
 
     *Required parameters:*
 
@@ -826,7 +826,7 @@ def playlists_list(
 
 
 def i18n_languages_list(key, part, hl=None):
-    """Returns a list of application languages that the YouTube website
+    r"""Returns a list of application languages that the YouTube website
     supports.
 
     *Required parameters:*
@@ -923,7 +923,7 @@ def playlist_items_list(
 
 
 def guide_categories_list(key, part, id=None, regionCode=None, hl=None):
-    """Returns a list of categories that can be associated with YouTube
+    r"""Returns a list of categories that can be associated with YouTube
     channels.
 
     *Required parameters:*
@@ -1304,7 +1304,7 @@ def channels_list(
 
 
 def captions_list(key, part, videoId, id=None, onBehalfOfContentOwner=None):
-    """Returns a list of caption tracks that are associated with a specified
+    r"""Returns a list of caption tracks that are associated with a specified
     video. Note that the API response does not contain the actual captions and
     that the  captions.download  method provides the ability to retrieve a
     caption track.


### PR DESCRIPTION
## Summary
- Fixes #397 (invalid escape codes in doc comments)
- Converts offending docstrings (module + functions in 5 files) to raw strings (`r"""`)
- No behavior change; purely mechanical fix for SyntaxWarning/DeprecationWarning
- All relevant tests pass; live functionality verified

## Test Plan
- [x] `python -c "import advertools as adv"` succeeds cleanly
- [x] `robotstxt_to_df` and other core functions work
- [x] `pytest tests/test_partition.py tests/test_extract.py` (88 passed)
- [x] `pytest tests/test_crawlytics.py` (99/101 passed; 2 pre-existing unrelated failures)

Closes #397