### PR TITLE
Add screenshot capturing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ ENV/
 
 # Ruff
 .ruff_cache/
+# Local screenshot recipe outputs
+advertools/code_recipes/screenshots/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 Change Log - advertools
 =======================
 
+
+Unreleased
+----------
+
+* Added
+    - New ``crawl_screenshots`` function and ``advertools screenshots`` CLI
+      command for capturing Playwright-powered page screenshots.
+    - Screenshot capturing strategies and recipes documentation.
+
 0.17.2 (2026-04-02)
 -------------------
 

--- a/advertools/__init__.py
+++ b/advertools/__init__.py
@@ -18,6 +18,7 @@ from advertools.regex import *
 from advertools.reverse_dns_lookup import reverse_dns_lookup
 from advertools.robotstxt import *
 from advertools.sitemaps import sitemap_to_df
+from advertools.screenshot_spider import crawl_screenshots
 from advertools.spider import crawl
 from advertools.stopwords import stopwords
 from advertools.url_builders import url_utm_ga

--- a/advertools/cli.py
+++ b/advertools/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import platform
 import socket
 import sys
@@ -42,6 +43,27 @@ def _split_options(options):
         if v == "False":
             d[k] = False
     return d
+
+
+def _load_json_cli_option(value, option_name):
+    if value is None:
+        return None
+    if value.startswith("@"):
+        file_path = value[1:]
+        try:
+            with open(file_path, encoding="utf-8") as json_file:
+                value = json_file.read()
+        except OSError as e:
+            print(
+                f"error: could not read JSON file for {option_name}: {e}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as e:
+        print(f"error: invalid JSON for {option_name}: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _format_df(df, head=10, precision=1):
@@ -273,6 +295,162 @@ advertools headers https://example.com example.jl --custom-settings LOG_FILE=log
 """,
     )
     headers_parser.set_defaults(func=headers)
+
+    # screenshots --------------------------
+
+    def screenshots(args):
+        if args.url_list:
+            url_list = args.url_list
+        else:
+            url_list = [url.strip() for url in sys.stdin.read().split()]
+        if not url_list:
+            print("error: please provide a value for url_list", file=sys.stderr)
+            sys.exit(1)
+        if args.custom_settings:
+            args.custom_settings = _split_options(args.custom_settings)
+
+        actions = _load_json_cli_option(args.actions_json, "--actions-json")
+        launch_options = _load_json_cli_option(
+            args.launch_options_json, "--launch-options-json"
+        )
+        context_kwargs = _load_json_cli_option(
+            args.context_kwargs_json, "--context-kwargs-json"
+        )
+
+        adv.crawl_screenshots(
+            url_list=url_list,
+            output_file=args.output_file,
+            screenshot_dir=args.screenshot_dir,
+            full_page=args.full_page,
+            image_type=args.image_type,
+            quality=args.quality,
+            wait_until=args.wait_until,
+            wait_for_timeout=args.wait_for_timeout,
+            actions=actions,
+            browser_type=args.browser_type,
+            launch_options=launch_options,
+            context_kwargs=context_kwargs,
+            custom_settings=args.custom_settings,
+            timeout=args.timeout,
+            run_id=args.run_id,
+        )
+
+    screenshots_parser = subparsers.add_parser(
+        "screenshots",
+        formatter_class=RawTextDefArgFormatter,
+        epilog="""
+Examples:
+---------
+
+capture full-page PNG screenshots for two URLs:
+
+advertools screenshots https://example.com https://python.org \\
+    screenshots.jl --screenshot-dir shots
+
+capture JPEG screenshots after waiting one second:
+
+advertools screenshots https://example.com screenshots.jl \\
+    --image-type jpeg --quality 80 --wait-ms 1000
+
+capture a mobile viewport using a JSON file:
+
+advertools screenshots https://example.com mobile.jl \\
+    --context-kwargs-json @mobile-context.json
+
+provide Playwright actions as a JSON file:
+
+advertools screenshots https://example.com actions.jl \\
+    --actions-json @actions.json
+
+set a 10 second navigation/screenshot timeout:
+
+advertools screenshots https://example.com screenshots.jl --timeout-ms 10000
+
+inline JSON is shell-sensitive. In fish/zsh/bash, prefer single-line JSON in
+single quotes or use @file.json:
+
+advertools screenshots https://example.com inline.jl \\
+    --actions-json '[{"method": "click", "args": ["#accept"]}]'
+"""
+        + epilog,
+        description="capture screenshots for a list of URLs",
+    )
+    screenshots_parser.add_argument(
+        "url_list", nargs="*", help="one or more URLs to screenshot"
+    )
+    screenshots_parser.add_argument(
+        "output_file", help="filepath - where to save metadata output (.jl/.jsonl)"
+    )
+    screenshots_parser.add_argument(
+        "--screenshot-dir", help="directory where screenshot image files are saved"
+    )
+    screenshots_parser.add_argument(
+        "--image-type",
+        choices=["png", "jpeg"],
+        default="png",
+        help="screenshot image type",
+    )
+    screenshots_parser.add_argument(
+        "--quality",
+        type=int,
+        help="JPEG quality from 0 to 100; only valid with --image-type jpeg",
+    )
+    screenshots_parser.add_argument(
+        "--no-full-page",
+        action="store_false",
+        dest="full_page",
+        default=True,
+        help="capture only the viewport instead of the full scrollable page",
+    )
+    screenshots_parser.add_argument(
+        "--wait-until",
+        choices=["load", "domcontentloaded", "networkidle", "commit"],
+        default="load",
+        help="Playwright navigation wait condition",
+    )
+    screenshots_parser.add_argument(
+        "--wait-ms",
+        dest="wait_for_timeout",
+        type=int,
+        help="milliseconds to wait before taking each screenshot",
+    )
+    screenshots_parser.add_argument(
+        "--timeout-ms",
+        dest="timeout",
+        type=int,
+        help="Playwright timeout in milliseconds for navigation and screenshot",
+    )
+    screenshots_parser.add_argument(
+        "--browser-type",
+        choices=["chromium", "firefox", "webkit"],
+        default="chromium",
+        help="Playwright browser type",
+    )
+    screenshots_parser.add_argument(
+        "--actions-json",
+        help="inline JSON or @file.json list of Playwright actions",
+    )
+    screenshots_parser.add_argument(
+        "--launch-options-json",
+        help="inline JSON or @file.json object with Playwright launch options",
+    )
+    screenshots_parser.add_argument(
+        "--context-kwargs-json",
+        help="inline JSON or @file.json object with Playwright context options",
+    )
+    screenshots_parser.add_argument(
+        "--run-id",
+        help="identifier included in screenshot filenames and metadata",
+    )
+    screenshots_parser.add_argument(
+        "--custom-settings",
+        type=str,
+        nargs="*",
+        help="""settings that modify the behavior of the crawler
+settings should be separated by spaces, and each setting name and value should
+be separated by an equal sign '=' without spaces between them""",
+    )
+    screenshots_parser.set_defaults(func=screenshots)
 
     # logs --------------------------
 

--- a/advertools/cli_docs/cli.py
+++ b/advertools/cli_docs/cli.py
@@ -315,6 +315,80 @@ Tokenize documents (phrases, keywords, tweets, etc.) into tokens of the desired 
 - **-l LENGTH, --length LENGTH**: Length of tokens (the `n` in n-grams). Default: 1.
 - **-s SEPARATOR, --separator SEPARATOR**: Character to separate the tokens. Default: `,`.
 
+Capture screenshots for a list of URLs
+=======================================
+
+**Usage**
+---------
+
+.. code-block:: console
+
+    advertools screenshots [-h] [--screenshot-dir SCREENSHOT_DIR]
+                           [--image-type {png,jpeg}] [--quality QUALITY]
+                           [--no-full-page]
+                           [--wait-until {load,domcontentloaded,networkidle,commit}]
+                           [--wait-ms WAIT_FOR_TIMEOUT] [--timeout-ms TIMEOUT]
+                           [--browser-type {chromium,firefox,webkit}]
+                           [--actions-json ACTIONS_JSON]
+                           [--launch-options-json LAUNCH_OPTIONS_JSON]
+                           [--context-kwargs-json CONTEXT_KWARGS_JSON]
+                           [--run-id RUN_ID]
+                           [--custom-settings [CUSTOM_SETTINGS ...]]
+                           [url_list ...] output_file
+
+**Description**
+---------------
+
+Capture screenshots for a list of URLs using the optional scrapy-playwright integration. Requires Python >= 3.10 for this optional feature and separately installed Playwright browser binaries. Supports http:// and https:// URLs only, obeys robots.txt by default, and replaces the metadata output file on each run.
+
+**Positional arguments:**
+
+- **url_list**: One or more URLs to screenshot. Default: None.
+- **output_file**: Filepath where to save metadata output (.jl/.jsonl).
+
+**Optional arguments:**
+
+- **-h, --help**: Show this help message and exit.
+- **--screenshot-dir SCREENSHOT_DIR**: Directory where screenshot image files are saved. Default: ``<output_file_stem>_screenshots``.
+- **--image-type {png,jpeg}**: Screenshot image type. Default: ``png``.
+- **--quality QUALITY**: JPEG quality from 0 to 100; only valid with ``--image-type jpeg``. Default: None.
+- **--no-full-page**: Capture only the viewport instead of the full scrollable page.
+- **--wait-until {load,domcontentloaded,networkidle,commit}**: Playwright navigation wait condition. Default: ``load``.
+- **--wait-ms WAIT_FOR_TIMEOUT**: Milliseconds to wait before taking each screenshot. Default: None.
+- **--timeout-ms TIMEOUT**: Playwright timeout in milliseconds for navigation and screenshot. Default: None.
+- **--browser-type {chromium,firefox,webkit}**: Playwright browser type. Default: ``chromium``.
+- **--actions-json ACTIONS_JSON**: Inline JSON or @file.json list of Playwright actions. Default: None.
+- **--launch-options-json LAUNCH_OPTIONS_JSON**: Inline JSON or @file.json object with Playwright launch options. Default: None.
+- **--context-kwargs-json CONTEXT_KWARGS_JSON**: Inline JSON or @file.json object with browser context options. Default: None.
+- **--custom-settings [CUSTOM_SETTINGS ...]**: Custom settings to modify the behavior of the crawler. Default: None.
+
+**Examples**
+------------
+
+Capture full-page PNG screenshots:
+
+.. code-block:: console
+
+    advertools screenshots https://example.com https://python.org screenshots.jl --screenshot-dir shots
+
+Capture JPEG screenshots after waiting one second:
+
+.. code-block:: console
+
+    advertools screenshots https://example.com screenshots.jl --image-type jpeg --quality 80 --wait-ms 1000
+
+Use JSON files for mobile viewport/action settings to avoid shell quoting issues:
+
+.. code-block:: console
+
+    advertools screenshots https://example.com mobile.jl --context-kwargs-json @mobile-context.json
+
+Set a navigation and screenshot timeout:
+
+.. code-block:: console
+
+    advertools screenshots https://example.com screenshots.jl --timeout-ms 10000
+
 SEO crawler
 ============
 

--- a/advertools/code_recipes/screenshot_strategies.py
+++ b/advertools/code_recipes/screenshot_strategies.py
@@ -1,0 +1,180 @@
+"""
+.. _screenshot_strategies:
+
+📸 Screenshot Capturing: Strategies & Recipes
+======================================================
+
+The :func:`advertools.crawl_screenshots` function saves page screenshots for a
+known list of URLs and writes a JSON Lines metadata file that can be loaded with
+pandas. This is useful for visual QA, archiving what a page looked like when it
+was crawled, checking JavaScript-rendered pages, or comparing desktop and mobile
+rendering.
+
+Screenshot capturing uses the optional ``scrapy-playwright`` integration. Install
+it and at least one browser before running these examples::
+
+    pip install "advertools[screenshots]"
+    playwright install chromium
+
+Screenshot metadata files in these recipes are written under the local
+``screenshots/`` folder next to this recipe module. That folder is ignored by
+git and is intended for local experiments. Metadata output files are replaced on
+every run.
+
+How do I capture screenshots for a list of URLs?
+************************************************
+
+Provide the URLs, the metadata output file, and optionally the screenshot
+folder. The output file contains one row per URL with the final URL, status,
+screenshot path, headers, and crawl time.
+
+.. code-block:: python
+
+    >>> import advertools as adv
+    >>> import pandas as pd
+
+    >>> adv.crawl_screenshots(
+    ...     ["https://example.com", "https://www.python.org"],
+    ...     "screenshots/basic.jl",
+    ...     screenshot_dir="screenshots/images",
+    ... )
+
+    >>> screenshot_df = pd.read_json("screenshots/basic.jl", lines=True)
+    >>> screenshot_df[["url", "status", "screenshot_path"]]
+
+How can I capture JPEG screenshots instead of PNG?
+**************************************************
+
+Use ``image_type="jpeg"`` and optionally set ``quality``. The ``quality``
+parameter is only valid for JPEG screenshots.
+
+.. code-block:: python
+
+    >>> adv.crawl_screenshots(
+    ...     "https://example.com",
+    ...     "screenshots/jpeg.jl",
+    ...     screenshot_dir="screenshots/jpeg_images",
+    ...     image_type="jpeg",
+    ...     quality=80,
+    ... )
+
+How can I capture only the viewport?
+************************************
+
+By default, screenshots are full-page screenshots. Set ``full_page=False`` to
+capture only the browser viewport.
+
+.. code-block:: python
+
+    >>> adv.crawl_screenshots(
+    ...     "https://example.com",
+    ...     "screenshots/viewport.jl",
+    ...     full_page=False,
+    ... )
+
+How can I emulate a mobile viewport?
+************************************
+
+Pass browser context options with ``context_kwargs``. Playwright supports many
+context settings; viewport and device scale factor are common for visual QA.
+
+.. code-block:: python
+
+    >>> adv.crawl_screenshots(
+    ...     "https://example.com",
+    ...     "screenshots/mobile.jl",
+    ...     screenshot_dir="screenshots/mobile_images",
+    ...     full_page=True,
+    ...     context_kwargs={
+    ...         "viewport": {"width": 390, "height": 844},
+    ...         "device_scale_factor": 2,
+    ...         "is_mobile": True,
+    ...     },
+    ... )
+
+How can I wait for content before taking the screenshot?
+********************************************************
+
+Use ``wait_until`` to control the navigation wait condition and
+``wait_for_timeout`` to wait a fixed number of milliseconds after navigation and
+actions. This can help with pages that load content after the initial HTML.
+
+.. code-block:: python
+
+    >>> adv.crawl_screenshots(
+    ...     "https://example.com",
+    ...     "screenshots/waited.jl",
+    ...     wait_until="networkidle",
+    ...     wait_for_timeout=1000,
+    ...     timeout=10000,
+    ... )
+
+How can I scroll, click, or wait for selectors before the screenshot?
+*********************************************************************
+
+Use ``actions`` to run serializable Playwright page methods before the screenshot
+is taken. Each action is a dictionary with a ``method`` and optional ``args`` /
+``kwargs``. The screenshot action is added automatically, so don't include it in
+``actions``.
+
+.. code-block:: python
+
+    >>> adv.crawl_screenshots(
+    ...     "https://example.com",
+    ...     "screenshots/actions.jl",
+    ...     actions=[
+    ...         {"method": "wait_for_selector", "args": ["body"]},
+    ...         {
+    ...             "method": "evaluate",
+    ...             "args": ["window.scrollTo(0, document.body.scrollHeight)"],
+    ...         },
+    ...         {"method": "wait_for_timeout", "args": [1000]},
+    ...     ],
+    ... )
+
+How can I compare desktop and mobile screenshots?
+*************************************************
+
+Run two screenshot capture jobs with the same URL list and different ``run_id`` and
+``context_kwargs`` values. The ``run_id`` is included in screenshot filenames and
+metadata, which makes it easy to join or compare results later.
+
+.. code-block:: python
+
+    >>> urls = ["https://example.com", "https://www.python.org"]
+
+    >>> adv.crawl_screenshots(
+    ...     urls,
+    ...     "screenshots/desktop.jl",
+    ...     screenshot_dir="screenshots/desktop_images",
+    ...     run_id="desktop",
+    ... )
+
+    >>> adv.crawl_screenshots(
+    ...     urls,
+    ...     "screenshots/mobile_compare.jl",
+    ...     screenshot_dir="screenshots/mobile_compare_images",
+    ...     run_id="mobile",
+    ...     context_kwargs={
+    ...         "viewport": {"width": 390, "height": 844},
+    ...         "is_mobile": True,
+    ...     },
+    ... )
+
+How can I use the command line?
+*******************************
+
+The ``screenshots`` command mirrors the Python API. It accepts URLs as arguments
+or from standard input. JSON flags can be inline JSON or ``@file.json``. Using
+JSON files avoids shell quoting issues in fish, zsh, and bash.
+
+.. code-block:: console
+
+    advertools screenshots https://example.com https://www.python.org \
+        screenshots/basic.jl --screenshot-dir screenshots/images
+
+    advertools screenshots https://www.python.org screenshots/mobile.jl \
+        --screenshot-dir screenshots/mobile_images \
+        --context-kwargs-json @screenshots/mobile-context.json
+
+"""

--- a/advertools/screenshot_spider.py
+++ b/advertools/screenshot_spider.py
@@ -1,0 +1,939 @@
+"""
+.. _crawl_screenshots:
+
+📸 Screenshot Capturing
+==============================
+
+Capture screenshots for a list of URLs and save crawl metadata to a JSON Lines
+file.
+
+The :func:`crawl_screenshots` function uses Scrapy together with the optional
+``scrapy-playwright`` package. It is designed for list-mode screenshot
+capture only: you supply one or more known URLs, screenshots are saved to disk,
+and one metadata
+row is written per URL.
+
+Installation
+------------
+
+Screenshot capturing requires optional browser automation dependencies and
+browser binaries. This optional feature requires Python >= 3.10, but the base
+``advertools`` install remains unchanged::
+
+    pip install "advertools[screenshots]"
+    playwright install chromium
+
+Only ``http://`` and ``https://`` URLs are supported. The metadata output file
+is replaced on every run. Screenshots are saved as image files and are not
+embedded in the JSON Lines metadata. The capture job obeys robots.txt by default,
+and concurrency can be tuned through ``custom_settings``.
+
+Basic Screenshot Capture
+------------------------
+
+Capture full-page PNG screenshots for a known list of URLs. This function does
+not discover links; feed it URLs from sitemaps, crawls, SERPs, logs, analytics
+exports, or your own lists.
+
+.. code-block:: python
+
+    import advertools as adv
+    import pandas as pd
+
+    adv.crawl_screenshots(
+        ["https://example.com", "https://www.python.org"],
+        "screenshots/basic.jl",
+        screenshot_dir="screenshots/images",
+        timeout=10000,
+    )
+
+    screenshot_df = pd.read_json("screenshots/basic.jl", lines=True)
+    screenshot_df[
+        [
+            "url",
+            "final_url",
+            "status",
+            "screenshot_path",
+            "screenshot_success",
+            "screenshot_size_bytes",
+        ]
+    ]
+
+JPEG Screenshots
+----------------
+
+Use JPEG when smaller files are more important than lossless PNG output.
+``quality`` is valid only with ``image_type="jpeg"``.
+
+.. code-block:: python
+
+    adv.crawl_screenshots(
+        "https://example.com",
+        "screenshots/jpeg.jl",
+        screenshot_dir="screenshots/jpeg_images",
+        image_type="jpeg",
+        quality=80,
+    )
+
+Viewport-Only Screenshots
+-------------------------
+
+By default, screenshots capture the full scrollable page. Set
+``full_page=False`` to capture only the current viewport.
+
+.. code-block:: python
+
+    adv.crawl_screenshots(
+        "https://example.com",
+        "screenshots/viewport.jl",
+        screenshot_dir="screenshots/viewport_images",
+        full_page=False,
+        context_kwargs={"viewport": {"width": 1440, "height": 900}},
+    )
+
+Mobile Rendering
+----------------
+
+Use Playwright browser context options to emulate a mobile viewport.
+
+.. code-block:: python
+
+    adv.crawl_screenshots(
+        "https://example.com",
+        "screenshots/mobile.jl",
+        screenshot_dir="screenshots/mobile_images",
+        context_kwargs={
+            "viewport": {"width": 390, "height": 844},
+            "device_scale_factor": 2,
+            "is_mobile": True,
+        },
+    )
+
+Waiting for Dynamic Content
+---------------------------
+
+Use ``wait_until`` for the navigation wait condition, ``wait_for_timeout`` for
+a fixed post-load delay, and ``timeout`` as a maximum for navigation and
+screenshot operations.
+
+.. code-block:: python
+
+    adv.crawl_screenshots(
+        "https://example.com",
+        "screenshots/waited.jl",
+        screenshot_dir="screenshots/waited_images",
+        wait_until="networkidle",
+        wait_for_timeout=1000,
+        timeout=15000,
+    )
+
+Cookie Banners, Lazy Loading, and Other Page Actions
+----------------------------------------------------
+
+Pass serializable Playwright page methods as ``actions``. The screenshot action
+is added automatically, so don't include ``{"method": "screenshot"}``.
+
+.. code-block:: python
+
+    adv.crawl_screenshots(
+        "https://example.com",
+        "screenshots/actions.jl",
+        screenshot_dir="screenshots/actions_images",
+        actions=[
+            {"method": "click", "args": ["#accept-cookies"], "timeout": 3000},
+            {"method": "wait_for_selector", "args": ["main"]},
+            {
+                "method": "evaluate",
+                "args": ["window.scrollTo(0, document.body.scrollHeight)"],
+            },
+            {"method": "wait_for_timeout", "args": [500]},
+        ],
+    )
+
+Desktop and Mobile Comparison
+-----------------------------
+
+Run separate crawls with the same URL list and different ``run_id`` values.
+The ``run_id`` is included in screenshot filenames and metadata.
+
+.. code-block:: python
+
+    urls = ["https://example.com", "https://www.python.org"]
+
+    adv.crawl_screenshots(
+        urls,
+        "screenshots/desktop_compare.jl",
+        screenshot_dir="screenshots/desktop_compare_images",
+        run_id="desktop",
+        context_kwargs={"viewport": {"width": 1440, "height": 900}},
+    )
+
+    adv.crawl_screenshots(
+        urls,
+        "screenshots/mobile_compare.jl",
+        screenshot_dir="screenshots/mobile_compare_images",
+        run_id="mobile",
+        context_kwargs={
+            "viewport": {"width": 390, "height": 844},
+            "is_mobile": True,
+        },
+    )
+
+Feeding URLs from Other advertools Functions
+--------------------------------------------
+
+Use screenshot capturing after discovering URLs with :func:`sitemap_to_df` or
+:func:`crawl`.
+
+.. code-block:: python
+
+    sitemap_df = adv.sitemap_to_df("https://www.example.com/sitemap.xml")
+    urls = sitemap_df["loc"].dropna().head(100)
+
+    adv.crawl_screenshots(
+        urls,
+        "screenshots/sitemap_urls.jl",
+        screenshot_dir="screenshots/sitemap_url_images",
+        custom_settings={"CONCURRENT_REQUESTS": 2},
+    )
+
+Command Line Examples
+---------------------
+
+The CLI mirrors the Python API. JSON options can be inline JSON or ``@file``
+references, which is safer for shell quoting.
+
+.. code-block:: console
+
+    advertools screenshots https://example.com https://www.python.org \
+        screenshots/basic.jl --screenshot-dir screenshots/images
+
+    advertools screenshots https://example.com screenshots/mobile.jl \
+        --screenshot-dir screenshots/mobile_images \
+        --context-kwargs-json @screenshots/mobile-context.json
+
+    advertools screenshots https://example.com screenshots/actions.jl \
+        --actions-json @screenshots/actions.json --timeout-ms 15000
+
+"""
+
+import datetime
+from contextlib import suppress
+import hashlib
+import importlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from urllib.parse import urlparse
+
+from scrapy import Request
+from scrapy.spiders import Spider
+
+from advertools import __version__ as adv_version
+
+screenshot_spider_path = os.path.abspath(__file__)
+
+user_agent = f"advertools/{adv_version}"
+
+_ALLOWED_IMAGE_TYPES = {"png", "jpeg"}
+_ALLOWED_URL_SCHEMES = {"http", "https"}
+_ALLOWED_WAIT_UNTIL = {"load", "domcontentloaded", "networkidle", "commit"}
+_DEFAULT_DOWNLOAD_HANDLERS = {
+    "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+    "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+}
+_DEFAULT_TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+_INTERNAL_META_KEYS = {
+    "playwright",
+    "playwright_page_methods",
+    "playwright_page_goto_kwargs",
+    "playwright_context",
+    "playwright_context_kwargs",
+    "screenshot_path",
+    "screenshot_type",
+    "screenshot_index",
+    "run_id",
+}
+
+
+def _now():
+    try:
+        utc = datetime.UTC
+    except AttributeError:
+        utc = datetime.timezone.utc
+    return datetime.datetime.now(utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _default_run_id():
+    try:
+        utc = datetime.UTC
+    except AttributeError:
+        utc = datetime.timezone.utc
+    return datetime.datetime.now(utc).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _safe_filename_part(value, max_length=80):
+    value = str(value or "").strip().lower()
+    value = re.sub(r"[^a-z0-9._-]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip("-._")
+    if not value:
+        value = "url"
+    return value[:max_length].strip("-._") or "url"
+
+
+def _url_slug(url, max_length=80):
+    parsed = urlparse(url)
+    if parsed.netloc:
+        raw_slug = parsed.netloc + parsed.path
+    elif parsed.path:
+        raw_slug = parsed.path
+    else:
+        raw_slug = url
+    return _safe_filename_part(raw_slug.replace("/", "-"), max_length=max_length)
+
+
+def _screenshot_filename(url, index, run_id, image_type):
+    url_hash = hashlib.sha1(url.encode("utf-8")).hexdigest()[:10]
+    safe_run_id = _safe_filename_part(run_id, max_length=40)
+    slug = _url_slug(url)
+    return f"{safe_run_id}-{int(index):05d}-{slug}-{url_hash}.{image_type}"
+
+
+def _screenshot_path(url, index, screenshot_dir, run_id, image_type):
+    filename = _screenshot_filename(url, index, run_id, image_type)
+    return os.path.normpath(os.path.join(screenshot_dir, filename))
+
+
+def _normalize_url_list(url_list):
+    if isinstance(url_list, str):
+        url_list = [url_list]
+    else:
+        try:
+            url_list = list(url_list)
+        except TypeError as e:
+            raise TypeError(
+                "url_list must be a URL string or an iterable of URLs"
+            ) from e
+    if not url_list:
+        raise ValueError("url_list must contain at least one URL")
+    normalized = []
+    for index, url in enumerate(url_list):
+        if not isinstance(url, str):
+            raise TypeError(f"url_list item at index {index} must be a string")
+        url = url.strip()
+        if not url:
+            raise ValueError(f"url_list item at index {index} must not be empty")
+        parsed = urlparse(url)
+        if parsed.scheme.lower() not in _ALLOWED_URL_SCHEMES or not parsed.netloc:
+            raise ValueError(
+                "url_list item at index {} must be an http:// or https:// URL; "
+                "got {!r}".format(index, url)
+            )
+        normalized.append(url)
+    return normalized
+
+
+def _validate_output_file(output_file):
+    output_file = os.fspath(output_file)
+    extension = output_file.rsplit(".", maxsplit=1)[-1]
+    if extension not in ["jl", "jsonl"]:
+        raise ValueError(
+            "Please make sure your output_file ends with '.jl' or '.jsonl'.\n"
+            "For example:\n"
+            "{}.jl".format(output_file.rsplit(".", maxsplit=1)[0])
+        )
+    return output_file
+
+
+def _validate_timeout(timeout, name):
+    if timeout is not None:
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or timeout < 0
+        ):
+            raise ValueError(f"{name} must be a non-negative number")
+
+
+def _validate_screenshot_options(
+    image_type, quality, wait_until, wait_for_timeout, timeout
+):
+    image_type = str(image_type).lower()
+    if image_type not in _ALLOWED_IMAGE_TYPES:
+        raise ValueError("image_type must be one of: 'png', 'jpeg'")
+    if quality is not None:
+        if image_type != "jpeg":
+            raise ValueError("quality can only be set when image_type='jpeg'")
+        if (
+            isinstance(quality, bool)
+            or not isinstance(quality, int)
+            or not 0 <= quality <= 100
+        ):
+            raise ValueError("quality must be an integer between 0 and 100")
+    if wait_until not in _ALLOWED_WAIT_UNTIL:
+        raise ValueError(
+            "wait_until must be one of: " + ", ".join(sorted(_ALLOWED_WAIT_UNTIL))
+        )
+    _validate_timeout(wait_for_timeout, "wait_for_timeout")
+    _validate_timeout(timeout, "timeout")
+    return image_type
+
+
+def _probe_writable_dir(directory):
+    os.makedirs(directory, exist_ok=True)
+    probe_file = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            delete=False,
+            dir=directory,
+            prefix=".advertools_write_probe_",
+            encoding="utf-8",
+        ) as temp_file:
+            probe_file = temp_file.name
+            temp_file.write("ok")
+    finally:
+        if probe_file is not None:
+            with suppress(OSError):
+                os.unlink(probe_file)
+
+
+def _prepare_output_paths(output_file, screenshot_dir):
+    output_parent = os.path.dirname(os.path.abspath(output_file)) or "."
+    os.makedirs(output_parent, exist_ok=True)
+
+    if os.path.exists(screenshot_dir) and not os.path.isdir(screenshot_dir):
+        raise ValueError("screenshot_dir exists and is not a directory")
+    os.makedirs(screenshot_dir, exist_ok=True)
+
+    if os.path.isdir(output_file):
+        raise ValueError("output_file exists and is a directory")
+
+    _probe_writable_dir(output_parent)
+    _probe_writable_dir(screenshot_dir)
+
+    if os.path.exists(output_file):
+        os.unlink(output_file)
+
+
+def _write_temp_json(data, prefix):
+    with tempfile.NamedTemporaryFile(
+        "w",
+        delete=False,
+        encoding="utf-8",
+        prefix=prefix,
+        suffix=".json",
+    ) as temp_file:
+        json.dump(data, temp_file)
+        return temp_file.name
+
+
+def _normalize_actions(actions):
+    """Return JSON-serializable Playwright action specs.
+
+    Each action must be a dictionary with a string ``method`` key. Optional
+    ``args`` must be a list/tuple, optional ``kwargs`` must be a dictionary.
+    Extra dictionary keys are treated as keyword arguments for convenience.
+    """
+    if actions is None:
+        return []
+    if not isinstance(actions, (list, tuple)):
+        raise TypeError("actions must be a list of dictionaries")
+
+    normalized = []
+    for action in actions:
+        if not isinstance(action, dict):
+            raise TypeError("each action must be a dictionary")
+        if "method" not in action or not isinstance(action["method"], str):
+            raise ValueError("each action must include a string 'method' key")
+        if action["method"] == "screenshot":
+            raise ValueError(
+                "actions should not include a screenshot action; "
+                "crawl_screenshots adds it automatically"
+            )
+        args = action.get("args", [])
+        kwargs = action.get("kwargs", {})
+        if not isinstance(args, (list, tuple)):
+            raise TypeError("action 'args' must be a list or tuple")
+        if not isinstance(kwargs, dict):
+            raise TypeError("action 'kwargs' must be a dictionary")
+        extra_kwargs = {
+            key: val
+            for key, val in action.items()
+            if key not in {"method", "args", "kwargs"}
+        }
+        merged_kwargs = dict(kwargs)
+        merged_kwargs.update(extra_kwargs)
+        normalized.append(
+            {
+                "method": action["method"],
+                "args": list(args),
+                "kwargs": merged_kwargs,
+            }
+        )
+    # Verify JSON serializability early, before launching a subprocess.
+    json.dumps(normalized)
+    return normalized
+
+
+def _load_page_method():
+    module = importlib.import_module("scrapy_playwright.page")
+    return module.PageMethod
+
+
+def _check_screenshot_dependencies():
+    if sys.version_info < (3, 10):
+        raise ImportError(
+            "Screenshot capturing requires Python >= 3.10 because "
+            "scrapy-playwright requires Python >= 3.10."
+        )
+    try:
+        _load_page_method()
+    except ImportError as exc:
+        raise ImportError(
+            "Screenshot capturing requires optional dependencies. Install them with:\n"
+            "    pip install 'advertools[screenshots]'\n"
+            "Then install browser binaries, for example:\n"
+            "    playwright install chromium"
+        ) from exc
+
+
+def _settings_to_cli_args(settings):
+    settings_list = []
+    for key, val in settings.items():
+        if isinstance(val, (dict, list, set, tuple)):
+            setting = "=".join([key, json.dumps(val)])
+        else:
+            setting = "=".join([key, str(val)])
+        settings_list.extend(["-s", setting])
+    return settings_list
+
+
+def _default_screenshot_settings(browser_type, launch_options):
+    launch_options = {"headless": True, **(launch_options or {})}
+    return {
+        "DOWNLOAD_HANDLERS": _DEFAULT_DOWNLOAD_HANDLERS,
+        "TWISTED_REACTOR": _DEFAULT_TWISTED_REACTOR,
+        "PLAYWRIGHT_BROWSER_TYPE": browser_type,
+        "PLAYWRIGHT_LAUNCH_OPTIONS": launch_options,
+        "CONCURRENT_REQUESTS": 4,
+        "CONCURRENT_REQUESTS_PER_DOMAIN": 2,
+        "PLAYWRIGHT_MAX_PAGES_PER_CONTEXT": 4,
+        "AUTOTHROTTLE_ENABLED": True,
+        "AUTOTHROTTLE_TARGET_CONCURRENCY": 2,
+    }
+
+
+def _build_screenshot_command(
+    output_file,
+    settings_list,
+    start_index=0,
+    url_list=None,
+    url_list_file=None,
+    screenshot_options=None,
+    screenshot_options_file=None,
+):
+    if url_list_file is None:
+        url_list_arg = "url_list=" + json.dumps(url_list)
+    else:
+        url_list_arg = "url_list_file=" + url_list_file
+    if screenshot_options_file is None:
+        screenshot_options_arg = "screenshot_options=" + json.dumps(
+            screenshot_options
+        )
+    else:
+        screenshot_options_arg = "screenshot_options_file=" + screenshot_options_file
+    return [
+        sys.executable,
+        "-m",
+        "scrapy",
+        "runspider",
+        screenshot_spider_path,
+        "-a",
+        url_list_arg,
+        "-a",
+        screenshot_options_arg,
+        "-a",
+        "start_index=" + str(start_index),
+        "-o",
+        output_file,
+    ] + settings_list
+
+
+def _page_methods(actions, wait_for_timeout, screenshot_path, screenshot_options):
+    PageMethod = _load_page_method()
+    methods = []
+    for action in actions:
+        methods.append(
+            PageMethod(
+                action["method"],
+                *action.get("args", []),
+                **action.get("kwargs", {}),
+            )
+        )
+    if wait_for_timeout is not None:
+        methods.append(PageMethod("wait_for_timeout", wait_for_timeout))
+
+    screenshot_kwargs = {
+        "path": screenshot_path,
+        "full_page": screenshot_options["full_page"],
+        "type": screenshot_options["image_type"],
+    }
+    if screenshot_options["quality"] is not None:
+        screenshot_kwargs["quality"] = screenshot_options["quality"]
+    if screenshot_options["timeout"] is not None:
+        screenshot_kwargs["timeout"] = screenshot_options["timeout"]
+    methods.append(PageMethod("screenshot", **screenshot_kwargs))
+    return methods
+
+
+def _screenshot_file_info(screenshot_path):
+    exists = bool(screenshot_path) and os.path.exists(screenshot_path)
+    size = os.path.getsize(screenshot_path) if exists else 0
+    return {
+        "screenshot_success": exists and size > 0,
+        "screenshot_exists": exists,
+        "screenshot_size_bytes": size,
+    }
+
+
+def _exception_error_fields(exception):
+    return {
+        "errors": repr(exception),
+        "error_type": type(exception).__name__,
+        "error_message": str(exception),
+    }
+
+
+def _failure_error_fields(failure):
+    exception = getattr(failure, "value", None)
+    if exception is None:
+        return {
+            "errors": repr(failure),
+            "error_type": type(failure).__name__,
+            "error_message": str(failure),
+        }
+    return {
+        "errors": repr(failure),
+        "error_type": type(exception).__name__,
+        "error_message": str(exception),
+    }
+
+
+def _safe_meta(meta):
+    return {
+        key: "@@".join(str(val) for val in value)
+        if isinstance(value, list)
+        else value
+        for key, value in meta.items()
+        if key not in _INTERNAL_META_KEYS and not key.startswith("playwright_")
+    }
+
+
+class ScreenshotSpider(Spider):
+    name = "screenshot_spider"
+    custom_settings = {
+        "USER_AGENT": user_agent,
+        "ROBOTSTXT_OBEY": True,
+        "HTTPERROR_ALLOW_ALL": True,
+        "DOWNLOAD_HANDLERS": _DEFAULT_DOWNLOAD_HANDLERS,
+        "TWISTED_REACTOR": _DEFAULT_TWISTED_REACTOR,
+        "CONCURRENT_REQUESTS": 4,
+        "CONCURRENT_REQUESTS_PER_DOMAIN": 2,
+        "PLAYWRIGHT_MAX_PAGES_PER_CONTEXT": 4,
+        "AUTOTHROTTLE_ENABLED": True,
+        "AUTOTHROTTLE_TARGET_CONCURRENCY": 2,
+    }
+
+    def __init__(
+        self,
+        url_list=None,
+        url_list_file=None,
+        screenshot_options=None,
+        screenshot_options_file=None,
+        start_index=0,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        if url_list_file is not None:
+            with open(url_list_file, encoding="utf-8") as urls_file:
+                self.start_urls = json.load(urls_file)
+        else:
+            self.start_urls = json.loads(url_list or "[]")
+        if screenshot_options_file is not None:
+            with open(screenshot_options_file, encoding="utf-8") as options_file:
+                self.screenshot_options = json.load(options_file)
+        else:
+            self.screenshot_options = json.loads(screenshot_options or "{}")
+        self.start_index = int(start_index)
+        self.context_name = "advertools_screenshots_" + _safe_filename_part(
+            self.screenshot_options.get("run_id"), max_length=40
+        )
+
+    def _request_meta(self, url, index, screenshot_path):
+        screenshot_options = self.screenshot_options
+        goto_kwargs = {"wait_until": screenshot_options["wait_until"]}
+        if screenshot_options["timeout"] is not None:
+            goto_kwargs["timeout"] = screenshot_options["timeout"]
+        meta = {
+            "playwright": True,
+            "playwright_page_goto_kwargs": goto_kwargs,
+            "playwright_page_methods": _page_methods(
+                screenshot_options["actions"],
+                screenshot_options["wait_for_timeout"],
+                screenshot_path,
+                screenshot_options,
+            ),
+            "screenshot_path": screenshot_path,
+            "screenshot_type": screenshot_options["image_type"],
+            "run_id": screenshot_options["run_id"],
+            "screenshot_index": index,
+        }
+        if screenshot_options.get("context_kwargs"):
+            meta.update(
+                {
+                    "playwright_context": self.context_name,
+                    "playwright_context_kwargs": screenshot_options["context_kwargs"],
+                }
+            )
+        return meta
+
+    def _start_requests(self):
+        for index, url in enumerate(self.start_urls, self.start_index):
+            screenshot_path = _screenshot_path(
+                url,
+                index,
+                self.screenshot_options["screenshot_dir"],
+                self.screenshot_options["run_id"],
+                self.screenshot_options["image_type"],
+            )
+            try:
+                yield Request(
+                    url,
+                    callback=self.parse,
+                    errback=self.errback,
+                    meta=self._request_meta(url, index, screenshot_path),
+                )
+            except Exception as e:
+                self.logger.error(repr(e))
+                yield {
+                    "url": url,
+                    "final_url": None,
+                    "status": None,
+                    "screenshot_path": screenshot_path,
+                    "screenshot_type": self.screenshot_options["image_type"],
+                    "run_id": self.screenshot_options["run_id"],
+                    "screenshot_index": index,
+                    "crawl_time": _now(),
+                    **_screenshot_file_info(screenshot_path),
+                    **_exception_error_fields(e),
+                }
+
+    def start_requests(self):
+        yield from self._start_requests()
+
+    async def start(self):
+        for request in self._start_requests():
+            yield request
+
+    def errback(self, failure):
+        self.logger.error(repr(failure))
+        request = failure.request
+        screenshot_path = request.meta.get("screenshot_path")
+        yield {
+            "url": request.url,
+            "final_url": None,
+            "status": None,
+            "screenshot_path": screenshot_path,
+            "screenshot_type": request.meta.get("screenshot_type"),
+            "run_id": request.meta.get("run_id"),
+            "screenshot_index": request.meta.get("screenshot_index"),
+            "crawl_time": _now(),
+            **_screenshot_file_info(screenshot_path),
+            **_failure_error_fields(failure),
+        }
+
+    def parse(self, response):
+        screenshot_path = response.meta.get("screenshot_path")
+        yield {
+            "url": response.request.url,
+            "final_url": response.url,
+            "crawl_time": _now(),
+            "status": response.status,
+            "screenshot_path": screenshot_path,
+            "screenshot_type": response.meta.get("screenshot_type"),
+            "run_id": response.meta.get("run_id"),
+            "screenshot_index": response.meta.get("screenshot_index"),
+            **_screenshot_file_info(screenshot_path),
+            "error_type": None,
+            "error_message": None,
+            "protocol": response.protocol,
+            **_safe_meta(response.meta),
+            **{
+                "resp_headers_" + k: v
+                for k, v in response.headers.to_unicode_dict().items()
+            },
+            **{
+                "request_headers_" + k: v
+                for k, v in response.request.headers.to_unicode_dict().items()
+            },
+        }
+
+
+def crawl_screenshots(
+    url_list,
+    output_file,
+    screenshot_dir=None,
+    *,
+    full_page=True,
+    image_type="png",
+    quality=None,
+    wait_until="load",
+    wait_for_timeout=None,
+    actions=None,
+    browser_type="chromium",
+    launch_options=None,
+    context_kwargs=None,
+    custom_settings=None,
+    timeout=None,
+    run_id=None,
+):
+    """Capture screenshots for a list of URLs.
+
+    Parameters
+    ----------
+    url_list : str, list
+      One or more URLs to capture. This function does not discover or follow links.
+    output_file : str
+      Path to the JSON Lines metadata output. Must end with ``.jl`` or ``.jsonl``.
+      Replaced on every run.
+    screenshot_dir : str
+      Directory where screenshots are saved. Defaults to
+      ``<output_file_stem>_screenshots``.
+    full_page : bool
+      Whether to capture the full scrollable page.
+    image_type : str
+      Screenshot format: ``"png"`` or ``"jpeg"``.
+    quality : int
+      JPEG quality between 0 and 100. Only valid with ``image_type="jpeg"``.
+    wait_until : str
+      Playwright navigation wait condition: ``load``, ``domcontentloaded``,
+      ``networkidle``, or ``commit``.
+    wait_for_timeout : int, float
+      Optional milliseconds to wait after custom actions and before screenshot.
+    actions : list
+      Optional serializable Playwright page actions. Each action is a dict with
+      ``method`` plus optional ``args`` and ``kwargs``.
+    browser_type : str
+      Playwright browser type: typically ``chromium``, ``firefox``, or ``webkit``.
+    launch_options : dict
+      Playwright launch options; merged with ``{"headless": True}``.
+    context_kwargs : dict
+      Browser context keyword arguments, such as viewport settings.
+    custom_settings : dict
+      Additional Scrapy settings. These override screenshot capture defaults.
+    timeout : int, float
+      Optional Playwright timeout in milliseconds for navigation and screenshot
+      operations.
+    run_id : str
+      Identifier included in screenshot filenames and metadata. Defaults to a
+      UTC timestamp.
+
+    Returns
+    -------
+    None
+      Writes a JSON Lines metadata file. Successful rows include screenshot
+      success fields such as ``screenshot_success``, ``screenshot_exists``, and
+      ``screenshot_size_bytes``. Failed rows include ``errors``, ``error_type``,
+      and ``error_message``.
+    """
+    url_list = _normalize_url_list(url_list)
+    output_file = _validate_output_file(output_file)
+    image_type = _validate_screenshot_options(
+        image_type, quality, wait_until, wait_for_timeout, timeout
+    )
+    actions = _normalize_actions(actions)
+    if screenshot_dir is None:
+        screenshot_dir = output_file.rsplit(".", maxsplit=1)[0] + "_screenshots"
+    else:
+        screenshot_dir = os.fspath(screenshot_dir)
+    if run_id is None:
+        run_id = _default_run_id()
+    else:
+        run_id = _safe_filename_part(run_id, max_length=40)
+    if context_kwargs is None:
+        context_kwargs = {}
+    if not isinstance(context_kwargs, dict):
+        raise TypeError("context_kwargs must be a dictionary")
+    if launch_options is not None and not isinstance(launch_options, dict):
+        raise TypeError("launch_options must be a dictionary")
+    if custom_settings is not None and not isinstance(custom_settings, dict):
+        raise TypeError("custom_settings must be a dictionary")
+    if browser_type not in {"chromium", "firefox", "webkit"}:
+        raise ValueError("browser_type must be one of: chromium, firefox, webkit")
+
+    _check_screenshot_dependencies()
+    _prepare_output_paths(output_file, screenshot_dir)
+
+    screenshot_options = {
+        "screenshot_dir": screenshot_dir,
+        "run_id": run_id,
+        "full_page": bool(full_page),
+        "image_type": image_type,
+        "quality": quality,
+        "wait_until": wait_until,
+        "wait_for_timeout": wait_for_timeout,
+        "timeout": timeout,
+        "actions": actions,
+        "context_kwargs": context_kwargs,
+    }
+
+    settings = _default_screenshot_settings(browser_type, launch_options)
+    if custom_settings is not None:
+        settings.update(custom_settings)
+    settings_list = _settings_to_cli_args(settings)
+
+    temp_files = []
+
+    try:
+        url_list_file = _write_temp_json(
+            url_list, "advertools_screenshot_urls_"
+        )
+        screenshot_options_file = _write_temp_json(
+            screenshot_options, "advertools_screenshot_options_"
+        )
+        temp_files.extend([url_list_file, screenshot_options_file])
+        command = _build_screenshot_command(
+            output_file,
+            settings_list,
+            url_list_file=url_list_file,
+            screenshot_options_file=screenshot_options_file,
+        )
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            "Screenshot capture failed with exit code {returncode}.\n"
+            "Browser type: {browser_type}\n"
+            "Output file: {output_file}\n"
+            "Screenshot directory: {screenshot_dir}\n"
+            "Make sure screenshot dependencies and browser binaries are "
+            "installed:\n"
+            "    pip install 'advertools[screenshots]'\n"
+            "    {python} -m playwright install {browser_type}\n"
+            "For Chromium specifically:\n"
+            "    {python} -m playwright install chromium".format(
+                returncode=e.returncode,
+                browser_type=browser_type,
+                output_file=output_file,
+                screenshot_dir=screenshot_dir,
+                python=sys.executable,
+            )
+        ) from e
+    finally:
+        for temp_file in temp_files:
+            with suppress(OSError):
+                os.unlink(temp_file)

--- a/docs/advertools.code_recipes.rst
+++ b/docs/advertools.code_recipes.rst
@@ -8,6 +8,7 @@ Submodules
    :maxdepth: 4
 
    advertools.code_recipes.spider_strategies
+   advertools.code_recipes.screenshot_strategies
 
 Module contents
 ---------------

--- a/docs/advertools.code_recipes.screenshot_strategies.rst
+++ b/docs/advertools.code_recipes.screenshot_strategies.rst
@@ -1,0 +1,4 @@
+.. automodule:: advertools.code_recipes.screenshot_strategies
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/advertools.rst
+++ b/docs/advertools.rst
@@ -33,6 +33,7 @@ Submodules
    advertools.robotstxt
    advertools.serp
    advertools.sitemaps
+   advertools.screenshot_spider
    advertools.spider
    advertools.stopwords
    advertools.twitter

--- a/docs/advertools.screenshot_spider.rst
+++ b/docs/advertools.screenshot_spider.rst
@@ -1,0 +1,4 @@
+.. automodule:: advertools.screenshot_spider
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,8 @@ To install advertools, run the following from the command line::
    Crawl Analytics <advertools.crawlytics>
    Crawl headers (HEAD method only) <advertools.header_spider>
    Crawl images <advertools.image_spider>
+   Capture screenshots <advertools.screenshot_spider>
+   Screenshot Capturing Strategies <advertools.code_recipes.screenshot_strategies>
    Crawl Logs Analysis <advertools.logs>
    Reverse DNS Lookup <advertools.reverse_dns_lookup>
    Analyze Search Engine Results (SERPs) <advertools.serp>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dynamic = ["description"]
 readme = "README.rst"
 keywords = ["seo", "marketing", "advertising", "adwords", "bingads", "search-engine-marketing", "online-marketing", "digital-marketing", "digital-advertising", "keywords"]
 
+[project.optional-dependencies]
+screenshots = ["scrapy-playwright>=0.0.46"]
+
 [project.scripts]
 advertools = "advertools.cli:main"
 adv = "advertools.cli:main"

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         ],
     },
     install_requires=requirements,
+    extras_require={"screenshots": ["scrapy-playwright>=0.0.46"]},
     license="MIT license",
     long_description=readme + "\n\n" + history,
     include_package_data=True,

--- a/tests/test_screenshot_spider.py
+++ b/tests/test_screenshot_spider.py
@@ -1,0 +1,693 @@
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from advertools import cli
+from advertools import screenshot_spider as ss
+
+
+def _command_value(command, name):
+    prefix = name + "="
+    for part in command:
+        if part.startswith(prefix):
+            return part[len(prefix) :]
+    raise AssertionError(f"{name!r} not found in command: {command}")
+
+
+def _json_arg_file(command, name):
+    path = Path(_command_value(command, name))
+    assert path.exists()
+    return path
+
+
+class _ScreenshotTestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/robots.txt":
+            self.send_response(404)
+            self.end_headers()
+            return
+        if self.path == "/redirect":
+            self.send_response(302)
+            self.send_header("Location", "/target")
+            self.end_headers()
+            return
+        if self.path == "/missing":
+            self.send_response(404)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"<html><body><main id='ready'>missing</main></body></html>"
+            )
+            return
+        if self.path == "/slow":
+            time.sleep(1)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        body = b"""
+        <html>
+          <head><title>Screenshot fixture</title></head>
+          <body style='min-height: 1400px'>
+            <main id='ready'>ready</main>
+          </body>
+        </html>
+        """
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def local_http_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _ScreenshotTestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_crawl_screenshots_raises_on_wrong_file_extension():
+    with pytest.raises(ValueError):
+        ss.crawl_screenshots("https://example.com", "myfile.wrong")
+
+
+@pytest.mark.parametrize(
+    "url_list, match",
+    [
+        ([], "at least one"),
+        (["https://example.com", 1], "index 1"),
+        ([""], "index 0"),
+        (["file:///tmp/example.html"], "http:// or https://"),
+        (["ftp://example.com/file"], "http:// or https://"),
+        (["example.com/path"], "http:// or https://"),
+    ],
+)
+def test_crawl_screenshots_rejects_invalid_urls(url_list, match):
+    with pytest.raises((TypeError, ValueError), match=match):
+        ss.crawl_screenshots(url_list, "output.jl")
+
+
+@pytest.mark.parametrize("image_type", ["gif", "jpg", "webp", ""])
+def test_crawl_screenshots_rejects_invalid_image_type(image_type):
+    with pytest.raises(ValueError, match="image_type"):
+        ss.crawl_screenshots("https://example.com", "output.jl", image_type=image_type)
+
+
+def test_crawl_screenshots_rejects_quality_for_png():
+    with pytest.raises(ValueError, match="quality"):
+        ss.crawl_screenshots("https://example.com", "output.jl", quality=80)
+
+
+@pytest.mark.parametrize("quality", [-1, 101, 50.5, "80"])
+def test_crawl_screenshots_rejects_bad_jpeg_quality(quality):
+    with pytest.raises(ValueError, match="quality"):
+        ss.crawl_screenshots(
+            "https://example.com", "output.jl", image_type="jpeg", quality=quality
+        )
+
+
+@pytest.mark.parametrize("timeout", [-1, "1000", True])
+def test_crawl_screenshots_rejects_invalid_timeout(timeout):
+    with pytest.raises(ValueError, match="timeout"):
+        ss.crawl_screenshots("https://example.com", "output.jl", timeout=timeout)
+
+
+@pytest.mark.parametrize("wait_for_timeout", [-1, "1000", True])
+def test_crawl_screenshots_rejects_invalid_wait_for_timeout(wait_for_timeout):
+    with pytest.raises(ValueError, match="wait_for_timeout"):
+        ss.crawl_screenshots(
+            "https://example.com", "output.jl", wait_for_timeout=wait_for_timeout
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"browser_type": "opera"}, "browser_type"),
+        ({"context_kwargs": []}, "context_kwargs"),
+        ({"launch_options": []}, "launch_options"),
+        ({"custom_settings": []}, "custom_settings"),
+    ],
+)
+def test_crawl_screenshots_rejects_invalid_option_types(kwargs, match):
+    with pytest.raises((TypeError, ValueError), match=match):
+        ss.crawl_screenshots("https://example.com", "output.jl", **kwargs)
+
+
+def test_screenshot_path_is_unique_and_filesystem_safe(tmp_path):
+    urls = [
+        "https://www.example.com/a page/?x=1,2",
+        "https://www.example.com/a page/?x=3,4",
+    ]
+    paths = [
+        ss._screenshot_path(url, i, str(tmp_path), "Run ID: 1", "png")
+        for i, url in enumerate(urls)
+    ]
+    assert paths[0] != paths[1]
+    for path in paths:
+        basename = os.path.basename(path)
+        assert basename.endswith(".png")
+        assert re.match(r"^[a-z0-9._-]+$", basename)
+        assert "run-id-1" in basename
+
+
+def test_normalize_actions_supports_args_kwargs_and_extra_kwargs():
+    actions = ss._normalize_actions(
+        [
+            {"method": "click", "args": ["#accept"], "timeout": 1000},
+            {
+                "method": "wait_for_selector",
+                "args": ["main"],
+                "kwargs": {"state": "visible"},
+            },
+        ]
+    )
+    assert actions == [
+        {"method": "click", "args": ["#accept"], "kwargs": {"timeout": 1000}},
+        {
+            "method": "wait_for_selector",
+            "args": ["main"],
+            "kwargs": {"state": "visible"},
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "actions, exc_type",
+    [
+        ({"method": "click"}, TypeError),
+        (["click"], TypeError),
+        ([{"args": ["#x"]}], ValueError),
+        ([{"method": "click", "args": "#x"}], TypeError),
+        ([{"method": "click", "kwargs": []}], TypeError),
+        ([{"method": "screenshot"}], ValueError),
+    ],
+)
+def test_normalize_actions_rejects_invalid_actions(actions, exc_type):
+    with pytest.raises(exc_type):
+        ss._normalize_actions(actions)
+
+
+def test_crawl_screenshots_reports_missing_optional_dependency(monkeypatch, tmp_path):
+    def missing_page_method():
+        raise ImportError("missing")
+
+    monkeypatch.setattr(ss, "_load_page_method", missing_page_method)
+    with pytest.raises(ImportError, match=r"advertools\[screenshots\]"):
+        ss.crawl_screenshots("https://example.com", tmp_path / "output.jl")
+
+
+def test_crawl_screenshots_reports_unsupported_python(monkeypatch, tmp_path):
+    monkeypatch.setattr(ss.sys, "version_info", (3, 9, 0))
+    with pytest.raises(ImportError, match="Python >= 3.10"):
+        ss.crawl_screenshots("https://example.com", tmp_path / "output.jl")
+
+
+def test_screenshot_spider_loads_options_and_urls_from_files(tmp_path):
+    options = {
+        "screenshot_dir": str(tmp_path),
+        "run_id": "run",
+        "full_page": True,
+        "image_type": "png",
+        "quality": None,
+        "wait_until": "load",
+        "wait_for_timeout": None,
+        "timeout": None,
+        "actions": [],
+        "context_kwargs": {},
+    }
+    options_file = tmp_path / "options.json"
+    urls_file = tmp_path / "urls.json"
+    options_file.write_text(json.dumps(options))
+    urls_file.write_text(json.dumps(["https://example.com"]))
+
+    spider = ss.ScreenshotSpider(
+        url_list_file=str(urls_file),
+        screenshot_options_file=str(options_file),
+    )
+
+    assert spider.start_urls == ["https://example.com"]
+    assert spider.screenshot_options == options
+
+
+def test_crawl_screenshots_prepares_filesystem_and_replaces_output(
+    monkeypatch, tmp_path
+):
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs))
+
+    monkeypatch.setattr(ss, "_check_screenshot_dependencies", lambda: None)
+    monkeypatch.setattr(ss.subprocess, "run", fake_run)
+
+    output_file = tmp_path / "nested" / "output.jl"
+    screenshot_dir = tmp_path / "shots"
+    output_file.parent.mkdir()
+    output_file.write_text("old data")
+
+    ss.crawl_screenshots(
+        "https://example.com/a,b?x=1",
+        output_file,
+        screenshot_dir=screenshot_dir,
+    )
+
+    assert screenshot_dir.is_dir()
+    assert output_file.parent.is_dir()
+    assert not output_file.exists()
+    assert len(commands) == 1
+
+
+def test_crawl_screenshots_rejects_screenshot_dir_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(ss, "_check_screenshot_dependencies", lambda: None)
+    screenshot_dir = tmp_path / "shots"
+    screenshot_dir.write_text("not a directory")
+    with pytest.raises(ValueError, match="screenshot_dir"):
+        ss.crawl_screenshots(
+            "https://example.com",
+            tmp_path / "output.jl",
+            screenshot_dir=screenshot_dir,
+        )
+
+
+def test_crawl_screenshots_builds_command_settings_and_temp_files(
+    monkeypatch, tmp_path
+):
+    commands = []
+    files_seen = []
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs))
+        url_file = _json_arg_file(command, "url_list_file")
+        options_file = _json_arg_file(command, "screenshot_options_file")
+        files_seen.extend([url_file, options_file])
+        assert json.loads(url_file.read_text()) == [
+            "https://example.com/a,b?x=1",
+            "https://example.com/other",
+        ]
+        options = json.loads(options_file.read_text())
+        assert options["run_id"] == "test-run"
+        assert options["image_type"] == "jpeg"
+        assert options["quality"] == 80
+        assert options["wait_until"] == "networkidle"
+        assert options["wait_for_timeout"] == 500
+        assert options["timeout"] == 10000
+        assert options["actions"][0]["method"] == "click"
+        assert options["context_kwargs"]["viewport"]["width"] == 390
+
+    monkeypatch.setattr(ss, "_check_screenshot_dependencies", lambda: None)
+    monkeypatch.setattr(ss.subprocess, "run", fake_run)
+
+    output_file = tmp_path / "output.jl"
+    screenshot_dir = tmp_path / "shots"
+    ss.crawl_screenshots(
+        ["https://example.com/a,b?x=1", "https://example.com/other"],
+        output_file,
+        screenshot_dir=screenshot_dir,
+        image_type="jpeg",
+        quality=80,
+        wait_until="networkidle",
+        wait_for_timeout=500,
+        timeout=10000,
+        actions=[{"method": "click", "args": ["#accept"]}],
+        browser_type="firefox",
+        launch_options={"timeout": 10000},
+        context_kwargs={"viewport": {"width": 390, "height": 844}},
+        custom_settings={"LOG_FILE": "screenshots.log", "CONCURRENT_REQUESTS": 1},
+        run_id="test run",
+    )
+
+    assert screenshot_dir.is_dir()
+    assert len(commands) == 1
+    command, kwargs = commands[0]
+    assert command[:4] == [sys.executable, "-m", "scrapy", "runspider"]
+    assert command[4] == ss.screenshot_spider_path
+    assert kwargs == {"check": True}
+    assert "LOG_FILE=screenshots.log" in command
+    assert "CONCURRENT_REQUESTS=1" in command
+    assert "PLAYWRIGHT_BROWSER_TYPE=firefox" in command
+    assert "PLAYWRIGHT_MAX_PAGES_PER_CONTEXT=4" in command
+    assert any(part.startswith("PLAYWRIGHT_LAUNCH_OPTIONS=") for part in command)
+    assert files_seen
+    assert all(not path.exists() for path in files_seen)
+
+
+def test_crawl_screenshots_cleans_temp_files_on_subprocess_failure(
+    monkeypatch, tmp_path
+):
+    files_seen = []
+
+    def fake_run(command, **kwargs):
+        files_seen.extend(
+            [
+                _json_arg_file(command, "url_list_file"),
+                _json_arg_file(command, "screenshot_options_file"),
+            ]
+        )
+        raise subprocess.CalledProcessError(returncode=9, cmd=command)
+
+    monkeypatch.setattr(ss, "_check_screenshot_dependencies", lambda: None)
+    monkeypatch.setattr(ss.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="playwright install chromium"):
+        ss.crawl_screenshots(
+            "https://example.com",
+            tmp_path / "output.jl",
+            screenshot_dir=tmp_path / "shots",
+        )
+
+    assert files_seen
+    assert all(not path.exists() for path in files_seen)
+
+
+def test_screenshot_file_info_reports_success_and_missing(tmp_path):
+    screenshot = tmp_path / "shot.png"
+    screenshot.write_bytes(b"png")
+    assert ss._screenshot_file_info(str(screenshot)) == {
+        "screenshot_success": True,
+        "screenshot_exists": True,
+        "screenshot_size_bytes": 3,
+    }
+    assert ss._screenshot_file_info(str(tmp_path / "missing.png")) == {
+        "screenshot_success": False,
+        "screenshot_exists": False,
+        "screenshot_size_bytes": 0,
+    }
+
+
+def test_errback_rows_include_structured_error_fields(tmp_path):
+    from scrapy import Request
+    from twisted.python.failure import Failure
+
+    spider = ss.ScreenshotSpider(
+        url_list=json.dumps(["https://example.com"]),
+        screenshot_options=json.dumps(
+            {
+                "screenshot_dir": str(tmp_path),
+                "run_id": "run",
+                "full_page": True,
+                "image_type": "png",
+                "quality": None,
+                "wait_until": "load",
+                "wait_for_timeout": None,
+                "timeout": None,
+                "actions": [],
+                "context_kwargs": {},
+            }
+        ),
+    )
+    request = Request(
+        "https://example.com",
+        meta={
+            "screenshot_path": str(tmp_path / "missing.png"),
+            "screenshot_type": "png",
+            "run_id": "run",
+            "screenshot_index": 0,
+        },
+    )
+    failure = Failure(ValueError("boom"))
+    failure.request = request
+
+    row = next(spider.errback(failure))
+
+    assert row["error_type"] == "ValueError"
+    assert row["error_message"] == "boom"
+    assert row["screenshot_success"] is False
+    assert row["screenshot_index"] == 0
+
+
+def test_screenshots_cli_forwards_arguments(monkeypatch):
+    captured = {}
+
+    class Tty:
+        def isatty(self):
+            return True
+
+    def fake_crawl_screenshots(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli.sys, "stdin", Tty())
+    monkeypatch.setattr(cli.adv, "crawl_screenshots", fake_crawl_screenshots)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "advertools",
+            "screenshots",
+            "https://example.com",
+            "output.jl",
+            "--screenshot-dir",
+            "shots",
+            "--image-type",
+            "jpeg",
+            "--quality",
+            "80",
+            "--no-full-page",
+            "--wait-until",
+            "domcontentloaded",
+            "--wait-ms",
+            "1000",
+            "--timeout-ms",
+            "10000",
+            "--browser-type",
+            "webkit",
+            "--actions-json",
+            '[{"method": "click", "args": ["#ok"]}]',
+            "--launch-options-json",
+            '{"timeout": 10000}',
+            "--context-kwargs-json",
+            '{"viewport": {"width": 390, "height": 844}}',
+            "--run-id",
+            "cli-run",
+            "--custom-settings",
+            "LOG_FILE=screen.log",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["url_list"] == ["https://example.com"]
+    assert captured["output_file"] == "output.jl"
+    assert captured["screenshot_dir"] == "shots"
+    assert captured["image_type"] == "jpeg"
+    assert captured["quality"] == 80
+    assert captured["full_page"] is False
+    assert captured["wait_until"] == "domcontentloaded"
+    assert captured["wait_for_timeout"] == 1000
+    assert captured["timeout"] == 10000
+    assert captured["browser_type"] == "webkit"
+    assert captured["actions"][0]["method"] == "click"
+    assert captured["launch_options"]["timeout"] == 10000
+    assert captured["context_kwargs"]["viewport"]["width"] == 390
+    assert captured["run_id"] == "cli-run"
+    assert captured["custom_settings"] == {"LOG_FILE": "screen.log"}
+
+
+def test_screenshots_cli_accepts_json_files(monkeypatch, tmp_path):
+    captured = {}
+    actions_file = tmp_path / "actions.json"
+    context_file = tmp_path / "context.json"
+    launch_file = tmp_path / "launch.json"
+    actions_file.write_text('[{"method": "wait_for_selector", "args": ["main"]}]')
+    context_file.write_text('{"viewport": {"width": 390, "height": 844}}')
+    launch_file.write_text('{"headless": true}')
+
+    class Tty:
+        def isatty(self):
+            return True
+
+    def fake_crawl_screenshots(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli.sys, "stdin", Tty())
+    monkeypatch.setattr(cli.adv, "crawl_screenshots", fake_crawl_screenshots)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "advertools",
+            "screenshots",
+            "https://example.com",
+            "output.jl",
+            "--actions-json",
+            "@" + str(actions_file),
+            "--context-kwargs-json",
+            "@" + str(context_file),
+            "--launch-options-json",
+            "@" + str(launch_file),
+        ],
+    )
+
+    cli.main()
+
+    assert captured["actions"][0]["method"] == "wait_for_selector"
+    assert captured["context_kwargs"]["viewport"]["height"] == 844
+    assert captured["launch_options"] == {"headless": True}
+
+
+def test_screenshots_cli_prefers_arguments_when_stdin_is_not_tty(monkeypatch):
+    captured = {}
+
+    class NonTty:
+        def isatty(self):
+            return False
+
+        def read(self):
+            raise AssertionError("stdin should not be read when URLs are provided")
+
+    def fake_crawl_screenshots(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli.sys, "stdin", NonTty())
+    monkeypatch.setattr(cli.adv, "crawl_screenshots", fake_crawl_screenshots)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "advertools",
+            "screenshots",
+            "https://example.com",
+            "output.jl",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["url_list"] == ["https://example.com"]
+    assert captured["output_file"] == "output.jl"
+
+
+def test_screenshots_cli_reads_urls_from_stdin(monkeypatch):
+    captured = {}
+
+    class NonTty:
+        def isatty(self):
+            return False
+
+        def read(self):
+            return "https://example.com\nhttps://python.org\n"
+
+    def fake_crawl_screenshots(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli.sys, "stdin", NonTty())
+    monkeypatch.setattr(cli.adv, "crawl_screenshots", fake_crawl_screenshots)
+    monkeypatch.setattr(sys, "argv", ["advertools", "screenshots", "output.jl"])
+
+    cli.main()
+
+    assert captured["url_list"] == ["https://example.com", "https://python.org"]
+    assert captured["output_file"] == "output.jl"
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--actions-json", "{bad-json"],
+        ["--actions-json", "@missing-file.json"],
+    ],
+)
+def test_screenshots_cli_rejects_invalid_json(monkeypatch, args):
+    called = False
+
+    class Tty:
+        def isatty(self):
+            return True
+
+    def fake_crawl_screenshots(**kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(cli.sys, "stdin", Tty())
+    monkeypatch.setattr(cli.adv, "crawl_screenshots", fake_crawl_screenshots)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["advertools", "screenshots", "https://example.com", "output.jl", *args],
+    )
+
+    with pytest.raises(SystemExit):
+        cli.main()
+    assert called is False
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ADV_TEST_SCREENSHOTS"),
+    reason="set ADV_TEST_SCREENSHOTS=1 to run browser-based screenshot tests",
+)
+def test_crawl_screenshots_local_integration(local_http_server, tmp_path):
+    pytest.importorskip("scrapy_playwright")
+    browsers = os.environ.get("ADV_TEST_SCREENSHOTS_BROWSERS", "chromium").split(",")
+
+    for browser in [browser.strip() for browser in browsers if browser.strip()]:
+        output_file = tmp_path / f"screenshots_{browser}.jl"
+        screenshot_dir = tmp_path / f"shots_{browser}"
+
+        ss.crawl_screenshots(
+            [
+                local_http_server + "/",
+                local_http_server + "/missing",
+                local_http_server + "/redirect",
+            ],
+            output_file,
+            screenshot_dir=screenshot_dir,
+            browser_type=browser,
+            image_type="jpeg",
+            quality=80,
+            full_page=False,
+            timeout=10000,
+            actions=[{"method": "wait_for_selector", "args": ["#ready"]}],
+            context_kwargs={"viewport": {"width": 390, "height": 844}},
+            custom_settings={"LOG_LEVEL": "ERROR"},
+        )
+
+        rows = [json.loads(line) for line in output_file.read_text().splitlines()]
+        assert len(rows) == 3
+        assert {row["status"] for row in rows} == {200, 404}
+        assert any(row["final_url"].endswith("/target") for row in rows)
+        for row in rows:
+            screenshot_path = Path(row["screenshot_path"])
+            assert screenshot_path.exists()
+            assert screenshot_path.stat().st_size > 0
+            assert row["screenshot_type"] == "jpeg"
+            assert row["screenshot_success"] is True
+            assert row["screenshot_exists"] is True
+            assert row["screenshot_size_bytes"] > 0
+            assert row["error_type"] is None
+            assert row["screenshot_index"] in [0, 1, 2]
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ADV_TEST_SCREENSHOTS"),
+    reason="set ADV_TEST_SCREENSHOTS=1 to run browser-based screenshot tests",
+)
+def test_crawl_screenshots_timeout_integration(local_http_server, tmp_path):
+    pytest.importorskip("scrapy_playwright")
+    output_file = tmp_path / "timeout.jl"
+
+    ss.crawl_screenshots(
+        local_http_server + "/slow",
+        output_file,
+        screenshot_dir=tmp_path / "timeout_shots",
+        timeout=1,
+        custom_settings={"LOG_LEVEL": "ERROR"},
+    )
+
+    rows = [json.loads(line) for line in output_file.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["screenshot_success"] is False
+    assert rows[0]["error_type"]
+    assert rows[0]["error_message"]


### PR DESCRIPTION
## Summary

Adds opt-in screenshot capturing support through:

- `adv.crawl_screenshots()`
- `advertools screenshots` CLI command
- optional dependency extra: `advertools[screenshots]`

Screenshots are captured with `scrapy-playwright`, saved as image files, and paired with JSON Lines metadata.

## Highlights

- Supports PNG/JPEG screenshots
- Full-page or viewport-only capture
- Mobile viewport/context options
- Playwright actions before capture
- Timeout support
- Structured metadata for success/error diagnostics
- CLI support for inline JSON and `@file.json`
- Tests and docs included

## Verification

```bash
python -m ruff check advertools/screenshot_spider.py tests/test_screenshot_spider.py advertools/code_recipes/screenshot_strategies.py